### PR TITLE
Guarantee that /usr/local/src exists

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -2,6 +2,7 @@
 
 # Fetch Sources
 
+mkdir -p /usr/local/src
 cd /usr/local/src
 
 git clone --depth 1 https://github.com/l-smash/l-smash


### PR DESCRIPTION
I just tried to use this container and when I obliterated my docker host and rebuilt, new trusty images don't seem to come with /usr/local/src (so this script has unclear behavior).
